### PR TITLE
add assembly attribute automatically

### DIFF
--- a/Xunit.DependencyInjection.Test/Startup.cs
+++ b/Xunit.DependencyInjection.Test/Startup.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 using Xunit.DependencyInjection.Demystifier;
 using Xunit.DependencyInjection.Logging;
 
-[assembly: TestFramework("Xunit.DependencyInjection.Test.Startup", "Xunit.DependencyInjection.Test")]
+//[assembly: TestFramework("Xunit.DependencyInjection.Test.Startup", "Xunit.DependencyInjection.Test")]
 namespace Xunit.DependencyInjection.Test
 {
     public class Startup : DependencyInjectionTestFramework

--- a/Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj
+++ b/Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj
@@ -5,9 +5,14 @@
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
+    <XunitStartupFullName>$(AssemblyName).Startup</XunitStartupFullName>
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="Xunit.TestFrameworkAttribute">
+      <_Parameter1>$(XunitStartupFullName)</_Parameter1>
+      <_Parameter2>$(AssemblyName)</_Parameter2>
+    </AssemblyAttribute>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.*"  Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     <PackageReference Include="xunit" Version="2.*" />

--- a/Xunit.DependencyInjection/Xunit.DependencyInjection.csproj
+++ b/Xunit.DependencyInjection/Xunit.DependencyInjection.csproj
@@ -17,4 +17,10 @@ Release notes:
     <PackageReference Include="xunit.extensibility.execution" Version="[2.2.0,3.0.0)" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="targets\Xunit.DependencyInjection.targets" Pack="true" PackagePath="build\netstandard2.0\Xunit.DependencyInjection.targets" />
+    <None Include="targets\Xunit.DependencyInjection.targets" Pack="true" PackagePath="buildTransitive\netstandard2.0\Xunit.DependencyInjection.targets" />
+    <None Include="targets\Xunit.DependencyInjection.targets" Pack="true" PackagePath="build\net461\Xunit.DependencyInjection.targets" />
+    <None Include="targets\Xunit.DependencyInjection.targets" Pack="true" PackagePath="buildTransitive\net461\Xunit.DependencyInjection.targets" />
+  </ItemGroup>
 </Project>

--- a/Xunit.DependencyInjection/targets/Xunit.DependencyInjection.targets
+++ b/Xunit.DependencyInjection/targets/Xunit.DependencyInjection.targets
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <XunitStartupFullName Condition="'$(XunitStartupFullName)'==''">$(AssemblyName).Startup</XunitStartupFullName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="Xunit.TestFrameworkAttribute">
+      <_Parameter1>$(XunitStartupFullName)</_Parameter1>
+      <_Parameter2>$(AssemblyName)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+</Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
 jobs:
 - job: Linux_Build_and_Test
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
   steps:
   - task: DotNetCoreInstaller@0
     inputs:
@@ -36,7 +36,7 @@ jobs:
       includePreviewVersions: true
 - job: MacOS_Build_and_Test
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-latest'
   steps:
   - task: DotNetCoreInstaller@0
     inputs:
@@ -58,7 +58,7 @@ jobs:
       includePreviewVersions: true
 - job: Windows_Build_and_Test
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-latest'
   steps:
     - task: DotNetCoreInstaller@0
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,62 +16,53 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
   steps:
-  - task: DotNetCoreInstaller@0
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
     inputs:
-      version: '2.2.100'
-  - task: DotNetCoreInstaller@0
-    inputs:
-      version: '3.1.301'
+      version: 3.1.x
   - task: DotNetCoreCLI@2
     inputs:
       command: build
       projects: 'Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj'
       arguments: '-c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True'
-      includePreviewVersions: true
   - task: DotNetCoreCLI@2
     inputs:
       command: test
       projects: 'Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj'
       arguments: '-c $(buildConfiguration)'
-      includePreviewVersions: true
 - job: MacOS_Build_and_Test
   pool:
     vmImage: 'macOS-latest'
   steps:
-  - task: DotNetCoreInstaller@0
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
     inputs:
-      version: '2.2.100'
-  - task: DotNetCoreInstaller@0
-    inputs:
-      version: '3.1.301'
+      version: 3.1.x
   - task: DotNetCoreCLI@2
     inputs:
       command: build
       projects: 'Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj'
       arguments: '-c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True'
-      includePreviewVersions: true
   - task: DotNetCoreCLI@2
     inputs:
       command: test
       projects: 'Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj'
       arguments: '-c $(buildConfiguration)'
-      includePreviewVersions: true
 - job: Windows_Build_and_Test
   pool:
     vmImage: 'windows-latest'
   steps:
-    - task: DotNetCoreInstaller@0
-      inputs:
-        version: '3.1.301'
-    - task: DotNetCoreCLI@2
-      inputs:
-        command: build
-        projects: 'Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj'
-        arguments: '-c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True'
-        includePreviewVersions: true
-    - task: DotNetCoreCLI@2
-      inputs:
-        command: test
-        projects: 'Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj'
-        arguments: '-c $(buildConfiguration)'
-        includePreviewVersions: true
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      version: 3.1.x
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: build
+      projects: 'Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj'
+      arguments: '-c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True'
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: test
+      projects: 'Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj'
+      arguments: '-c $(buildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
       version: '2.2.100'
   - task: DotNetCoreInstaller@0
     inputs:
-      version: '3.0.100-preview7-012821'
+      version: '3.1.301'
   - task: DotNetCoreCLI@2
     inputs:
       command: build
@@ -43,7 +43,7 @@ jobs:
       version: '2.2.100'
   - task: DotNetCoreInstaller@0
     inputs:
-      version: '3.0.100-preview7-012821'
+      version: '3.1.301'
   - task: DotNetCoreCLI@2
     inputs:
       command: build
@@ -62,7 +62,7 @@ jobs:
   steps:
     - task: DotNetCoreInstaller@0
       inputs:
-        version: '3.0.100-preview7-012821'
+        version: '3.1.301'
     - task: DotNetCoreCLI@2
       inputs:
         command: build

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
use targets file to add assembly attribute automatically

if `Startup` does not match `$(AssemblyName).Startup`, user could define `XunitStartupFullName` property manually

for example:

``` xml
<PropertyGroup>
  <XunitStartupFullName>XUnitTestDemo1.Startup</XunitStartupFullName>
</PropertyGroup>
```