### PR TITLE
Optimize startup

### DIFF
--- a/Xunit.DependencyInjection.Test/StartupTest.cs
+++ b/Xunit.DependencyInjection.Test/StartupTest.cs
@@ -75,6 +75,10 @@ namespace Xunit.DependencyInjection.Test
             public void ConfigureHost(IHostBuilder builder) { }
             public void ConfigureHost(StringBuilder builder) { }
         }
+        public class ConfigureHostTestStartup8
+        {
+            public HostBuilder ConfigureHost() => new HostBuilder();
+        }
 
         [Fact]
         public void ConfigureHostTest()
@@ -98,6 +102,8 @@ namespace Xunit.DependencyInjection.Test
             Assert.Throws<InvalidOperationException>(() => StartupLoader.ConfigureHost(hostBuilder, new ConfigureHostTestStartup6()));
 
             Assert.Throws<InvalidOperationException>(() => StartupLoader.ConfigureHost(hostBuilder, new ConfigureHostTestStartup7()));
+
+            Assert.NotEqual(hostBuilder, StartupLoader.ConfigureHost(hostBuilder, new ConfigureHostTestStartup8()));
 
             var services = hostBuilder.Build().Services;
             Assert.NotNull(services.GetService<ConfigureHostTestStartup1>());

--- a/Xunit.DependencyInjection/DependencyInjectionTestFramework.cs
+++ b/Xunit.DependencyInjection/DependencyInjectionTestFramework.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Microsoft.Extensions.Configuration;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -11,7 +12,9 @@ namespace Xunit.DependencyInjection
 {
     public sealed class DependencyInjectionTestFramework : XunitTestFramework
     {
-        public DependencyInjectionTestFramework(IMessageSink messageSink) : base(messageSink) { }
+        public DependencyInjectionTestFramework(IMessageSink messageSink) : base(messageSink)
+        {
+        }
 
         protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
         {
@@ -28,8 +31,9 @@ namespace Xunit.DependencyInjection
 
                 host = hostBuilder
                     .ConfigureServices(services => services
-                        .AddSingleton<ITestOutputHelperAccessor, TestOutputHelperAccessor>()
-                        .AddSingleton(DiagnosticMessageSink))
+                        .AddSingleton(DiagnosticMessageSink)
+                        .TryAddSingleton<ITestOutputHelperAccessor, TestOutputHelperAccessor>()
+                        )
                     .Build();
 
                 StartupLoader.Configure(host.Services, startup);

--- a/Xunit.DependencyInjection/StartupLoader.cs
+++ b/Xunit.DependencyInjection/StartupLoader.cs
@@ -45,6 +45,15 @@ namespace Xunit.DependencyInjection
             if (method == null) return builder;
 
             var parameters = method.GetParameters();
+            if (parameters.Length == 0)
+            {
+                if (typeof(IHostBuilder).IsAssignableFrom(method.ReturnType))
+                {
+                    return method.Invoke(startup, Array.Empty<object>()) as IHostBuilder ?? builder;
+                }
+                throw new InvalidOperationException($"The '{method.Name}' method of startup type '{startup.GetType().FullName}' must have the only 'IHostBuilder' parameter or return a 'IHostBuilder' instance.");
+            }
+
             if (parameters.Length != 1 || parameters[0].ParameterType != typeof(IHostBuilder))
                 throw new InvalidOperationException($"The '{method.Name}' method of startup type '{startup.GetType().FullName}' must have the only 'IHostBuilder' parameter.");
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ after_build:
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:
-  - dotnet build
+  - dotnet build -v n /p:TreatWarningsAsErrors=True
 # to disable automatic builds
 #build: off
 


### PR DESCRIPTION
- register `ITestOutputHelperAccessor` use `TryAdd`
- allow `ConfigureHost` return hostBuilder without method parameter