### PR TITLE
Add support for disabling default attributes

### DIFF
--- a/Xunit.DependencyInjection/targets/Xunit.DependencyInjection.targets
+++ b/Xunit.DependencyInjection/targets/Xunit.DependencyInjection.targets
@@ -5,12 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AssemblyAttribute Include="Xunit.TestFramework">
+    <AssemblyAttribute Include="Xunit.TestFramework"
+                       Condition="'$(EnableXunitDependencyInjectionDefaultTestFrameworkAttribute)' == '' OR '$(EnableXunitDependencyInjectionDefaultTestFrameworkAttribute)' == 'true'">
       <_Parameter1>Xunit.DependencyInjection.DependencyInjectionTestFramework</_Parameter1>
       <_Parameter2>Xunit.DependencyInjection</_Parameter2>
     </AssemblyAttribute>
 
-    <AssemblyAttribute Include="Xunit.DependencyInjection.StartupType">
+    <AssemblyAttribute Include="Xunit.DependencyInjection.StartupType"
+                       Condition="'$(EnableXunitDependencyInjectionDefaultStartupTypeAttribute)' == '' OR '$(EnableXunitDependencyInjectionDefaultStartupTypeAttribute)' == 'true'">
       <_Parameter1>$(XunitStartupFullName)</_Parameter1>
       <_Parameter2 Condition="'$(XunitStartupAssembly)' != ''">$(XunitStartupAssembly)</_Parameter2>
     </AssemblyAttribute>


### PR DESCRIPTION
When combining this with other Xunit extension libraries, it might be necessary to declare custom `Xunit.TestFramework` attribute. When you do this, however, you get an error about a duplicate attribute:

![Duplicate attribute error](https://user-images.githubusercontent.com/20975774/92811341-a4a78800-f3be-11ea-84d9-61ca4ed726f9.png)

This adds two new MSBuild variables similar to  Microsoft's `EnableDefaultCompileItems` that allow users to disable the generation of the `Xunit.TestFramework` and, to have the option for both generated attributes, the `Xunit.DependencyInjection.StartupType` attribute.