### PR TITLE
use net 5.0 sdk for azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,10 @@ jobs:
     displayName: 'Use .NET Core sdk 3.1'
     inputs:
       version: 3.1.x
+  - task: UseDotNet@2
+    displayName: 'Use .NET sdk 5.0'
+    inputs:
+      version: 5.0.x
   - script: dotnet build -c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True
     displayName: 'dotnet build'
   - script: dotnet test -c $(buildConfiguration)
@@ -41,6 +45,10 @@ jobs:
     displayName: 'Use .NET Core sdk 3.1'
     inputs:
       version: 3.1.x
+  - task: UseDotNet@2
+    displayName: 'Use .NET sdk 5.0'
+    inputs:
+      version: 5.0.x
   - script: dotnet build -c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True
     displayName: 'dotnet build'
   - script: dotnet test -c $(buildConfiguration)
@@ -58,6 +66,10 @@ jobs:
     displayName: 'Use .NET Core sdk 3.1'
     inputs:
       version: 3.1.x
+  - task: UseDotNet@2
+    displayName: 'Use .NET sdk 5.0'
+    inputs:
+      version: 5.0.x
   - script: dotnet build -c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True
     displayName: 'dotnet build'
   - script: dotnet test -c $(buildConfiguration)


### PR DESCRIPTION
use net 5.0 sdk for azure pipeline to fix azure devops ci build