### PR TITLE
fix ObjectDisposedException on theory

### DIFF
--- a/Xunit.DependencyInjection.Test/TheoryTest.cs
+++ b/Xunit.DependencyInjection.Test/TheoryTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Xunit.DependencyInjection.Test
 {
@@ -6,19 +7,44 @@ namespace Xunit.DependencyInjection.Test
     {
         [Theory]
         [MemberData(nameof(GetComplexData))]
-        public void ComplexParameterizedTest(string arg1, Dictionary<string, string> arg2, Dictionary<string, string> arg3)
+        public void ComplexParameterizedTest(string arg1, Dictionary<string, string> arg2, Dictionary<string, string> arg3, int delay)
         {
             Assert.Equal("Test", arg1);
             Assert.Equal("Value", arg2["Key"]);
             Assert.Equal("Value", arg3["Key"]);
+            Assert.True(delay >= 0);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetComplexData))]
+        public async Task ComplexParameterizedTestAsync(string arg1, Dictionary<string, string> arg2, Dictionary<string, string> arg3, int delay)
+        {
+            Assert.Equal("Test", arg1);
+            Assert.Equal("Value", arg2["Key"]);
+            Assert.Equal("Value", arg3["Key"]);
+            Assert.True(delay >= 0);
+
+            await Task.Delay(delay).ConfigureAwait(false);
         }
 
         [Theory]
         [MemberData(nameof(GetSimpleData))]
-        public void SimpleParameterizedTest(string arg1, int arg2)
+        public void SimpleParameterizedTest(string arg1, int arg2, int delay)
         {
             Assert.Equal("Test", arg1);
             Assert.Equal(1, arg2);
+            Assert.True(delay >= 0);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetSimpleData))]
+        public async Task SimpleParameterizedTestAsync(string arg1, int arg2, int delay)
+        {
+            Assert.Equal("Test", arg1);
+            Assert.Equal(1, arg2);
+            Assert.True(delay >= 0);
+
+            await Task.Delay(delay).ConfigureAwait(false);
         }
 
         [Theory]
@@ -33,7 +59,15 @@ namespace Xunit.DependencyInjection.Test
         {
             yield return new object[]
             {
-                "Test", 1
+                "Test", 1, 0
+            };
+            yield return new object[]
+            {
+                "Test", 1, 10
+            };
+            yield return new object[]
+            {
+                "Test", 1, 1
             };
         }
 
@@ -49,7 +83,36 @@ namespace Xunit.DependencyInjection.Test
                 new Dictionary<string, string>
                 {
                     { "Key", "Value"}
-                }
+                },
+                0
+            };
+
+            yield return new object[]
+            {
+                "Test",
+                new Dictionary<string, string>
+                {
+                    { "Key", "Value"}
+                },
+                new Dictionary<string, string>
+                {
+                    { "Key", "Value"}
+                },
+                10
+            };
+
+            yield return new object[]
+            {
+                "Test",
+                new Dictionary<string, string>
+                {
+                    { "Key", "Value"}
+                },
+                new Dictionary<string, string>
+                {
+                    { "Key", "Value"}
+                },
+                1
             };
         }
     }

--- a/Xunit.DependencyInjection/DependencyInjectionTestMethodRunner.cs
+++ b/Xunit.DependencyInjection/DependencyInjectionTestMethodRunner.cs
@@ -61,11 +61,16 @@ namespace Xunit.DependencyInjection
         }
 
         /// <inheritdoc />
-        protected override Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase)
+        protected override async Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase)
         {
             if (testCase is ExecutionErrorTestCase)
-                return testCase.RunAsync(_diagnosticMessageSink, MessageBus,
-                    _constructorArguments, new ExceptionAggregator(Aggregator), CancellationTokenSource);
+                return await testCase
+                    .RunAsync(
+                        _diagnosticMessageSink,
+                        MessageBus, _constructorArguments,
+                        new ExceptionAggregator(Aggregator),
+                        CancellationTokenSource)
+                    .ConfigureAwait(false);
 
             using var scope = _provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
 
@@ -76,13 +81,26 @@ namespace Xunit.DependencyInjection
             {
                 var wrapper = wrappers.FirstOrDefault(w => w.TestCaseType == type);
                 if (wrapper != null)
-                    return wrapper.RunAsync(testCase, scope.ServiceProvider, _diagnosticMessageSink,
-                        MessageBus, CreateTestClassConstructorArguments(scope.ServiceProvider),
-                        new ExceptionAggregator(Aggregator), CancellationTokenSource);
+                    return await wrapper
+                        .RunAsync(
+                            testCase,
+                            scope.ServiceProvider,
+                            _diagnosticMessageSink,
+                            MessageBus,
+                            CreateTestClassConstructorArguments(scope.ServiceProvider),
+                            new ExceptionAggregator(Aggregator),
+                            CancellationTokenSource)
+                        .ConfigureAwait(false);
             } while ((type = type.BaseType) != null);
 
-            return testCase.RunAsync(_diagnosticMessageSink, MessageBus,
-                _constructorArguments, new ExceptionAggregator(Aggregator), CancellationTokenSource);
+            return await testCase
+                .RunAsync(
+                    _diagnosticMessageSink,
+                    MessageBus,
+                    _constructorArguments,
+                    new ExceptionAggregator(Aggregator),
+                    CancellationTokenSource)
+                .ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
I had this error after run tests from latest package version (7.5.0)
```
System.ObjectDisposedException : Cannot access a disposed object.
Object name: 'IServiceProvider'.
```

Firstly I tried to had same exception on your tests. So I made some changes in `TheoryTest` wchich bring me same error:
![image](https://user-images.githubusercontent.com/7288991/131475528-a3b43f12-986e-4ca2-bd9b-d2ddd6171ca8.png)

After investigation I've notice that you have `using var scope` but returns Task, which can be executed later. So I've refactor it and use `asyc` to make sure that  `testCase.RunAsync()` is executed before `using var scope` had been disposed.