### PR TITLE
Add License Metadata to Package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
     <RepositoryType>git</RepositoryType>
     <SignAssembly>True</SignAssembly>
     <PackageProjectUrl>https://github.com/pengweiqhca/Xunit.DependencyInjection</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add `PackageLicenseExpression` to the `Directory.Build.props`

Resolve #64
