### PR TITLE
xRetry integration

### DIFF
--- a/Xunit.DependencyInjection.Test/Startup.cs
+++ b/Xunit.DependencyInjection.Test/Startup.cs
@@ -21,6 +21,7 @@ public class Startup
             .AddHostedService<HostServiceTest>()
             .AddSkippableFactSupport()
             .AddStaFactSupport()
+            .AddXRetrySupport()
             .AddSingleton<IAsyncExceptionFilter, DemystifyExceptionFilter>();
 
     public void Configure(IServiceProvider provider, ITestOutputHelperAccessor accessor)

--- a/Xunit.DependencyInjection.Test/XRetryTest.cs
+++ b/Xunit.DependencyInjection.Test/XRetryTest.cs
@@ -1,5 +1,4 @@
 ﻿using xRetry;
-using Xunit;
 
 namespace Xunit.DependencyInjection.Test;
 

--- a/Xunit.DependencyInjection.Test/XRetryTest.cs
+++ b/Xunit.DependencyInjection.Test/XRetryTest.cs
@@ -3,12 +3,12 @@ using Xunit;
 
 namespace Xunit.DependencyInjection.Test;
 
-public class xRetryTest
+public class XRetryTest
 {
     private readonly IDependency _dependency;
     private static int _factNumCalls = 0;
     // testId => numCalls
-    private static Dictionary<int, int> _theoryNumCalls = new()
+    private static readonly Dictionary<int, int> _theoryNumCalls = new()
     {
         { 0, 0 },
         { 1, 0 }
@@ -20,7 +20,7 @@ public class xRetryTest
         { 1, 0 }
     };
 
-    public xRetryTest(IDependency dependency)
+    public XRetryTest(IDependency dependency)
     {
         _dependency = dependency;
     }

--- a/Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj
+++ b/Xunit.DependencyInjection.Test/Xunit.DependencyInjection.Test.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\Xunit.DependencyInjection.Logging\Xunit.DependencyInjection.Logging.csproj" />
     <ProjectReference Include="..\Xunit.DependencyInjection.SkippableFact\Xunit.DependencyInjection.SkippableFact.csproj" />
     <ProjectReference Include="..\Xunit.DependencyInjection.StaFact\Xunit.DependencyInjection.StaFact.csproj" />
+    <ProjectReference Include="..\Xunit.DependencyInjection.xRetry\Xunit.DependencyInjection.xRetry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Xunit.DependencyInjection.Test/xRetryTest.cs
+++ b/Xunit.DependencyInjection.Test/xRetryTest.cs
@@ -1,15 +1,24 @@
 ﻿using xRetry;
+using Xunit;
 
 namespace Xunit.DependencyInjection.Test;
 
 public class xRetryTest
 {
+    private readonly IDependency _dependency;
     private static int _nFact = 0;
     private static int _nTheory = 0;
+
+    public xRetryTest(IDependency dependency)
+    {
+        _dependency = dependency;
+    }
 
     [RetryFact]
     public void RetryFact()
     {
+        AssertDependencyUnique();
+
         _nFact++;
         Assert.Equal(3, _nFact);
     }
@@ -18,7 +27,51 @@ public class xRetryTest
     [InlineData(3)]
     public void RetryTheory(int expected)
     {
+        AssertDependencyUnique();
+
         _nTheory++;
         Assert.Equal(expected, _nTheory);
+    }
+
+    public class NonSerializableTestData
+    {
+        public readonly int Id;
+
+        public NonSerializableTestData(int id)
+        {
+            Id = id;
+        }
+    }
+
+    // testId => numCalls
+    private static readonly Dictionary<int, int> _defaultNumCalls = new()
+    {
+        { 0, 0 },
+        { 1, 0 }
+    };
+
+    [RetryTheory]
+    [MemberData(nameof(GetTestData))]
+    public void RetryTheoryNonSerializableData(NonSerializableTestData nonSerializableWrapper)
+    {
+        AssertDependencyUnique();
+
+        _defaultNumCalls[nonSerializableWrapper.Id]++;
+        Assert.Equal(3, _defaultNumCalls[nonSerializableWrapper.Id]);
+    }
+
+    public static IEnumerable<object[]> GetTestData() => new[]
+    {
+        new object[] { new NonSerializableTestData(0) },
+        new object[] { new NonSerializableTestData(1) }
+    };
+
+    private void AssertDependencyUnique()
+    {
+        // Assert dependency is in its original state
+        Assert.Equal(0, _dependency.Value);
+
+        // Modify the dependency so that a retry of this test case would fail if it got the same instance
+        _dependency.Value++;
     }
 }

--- a/Xunit.DependencyInjection.Test/xRetryTest.cs
+++ b/Xunit.DependencyInjection.Test/xRetryTest.cs
@@ -1,0 +1,24 @@
+﻿using xRetry;
+
+namespace Xunit.DependencyInjection.Test;
+
+public class xRetryTest
+{
+    private static int _nFact = 0;
+    private static int _nTheory = 0;
+
+    [RetryFact]
+    public void RetryFact()
+    {
+        _nFact++;
+        Assert.Equal(3, _nFact);
+    }
+
+    [RetryTheory]
+    [InlineData(3)]
+    public void RetryTheory(int expected)
+    {
+        _nTheory++;
+        Assert.Equal(expected, _nTheory);
+    }
+}

--- a/Xunit.DependencyInjection.Test/xRetryTest.cs
+++ b/Xunit.DependencyInjection.Test/xRetryTest.cs
@@ -6,8 +6,19 @@ namespace Xunit.DependencyInjection.Test;
 public class xRetryTest
 {
     private readonly IDependency _dependency;
-    private static int _nFact = 0;
-    private static int _nTheory = 0;
+    private static int _factNumCalls = 0;
+    // testId => numCalls
+    private static Dictionary<int, int> _theoryNumCalls = new()
+    {
+        { 0, 0 },
+        { 1, 0 }
+    };
+    // testId => numCalls
+    private static readonly Dictionary<int, int> _nonSerializableTheoryNumCalls = new()
+    {
+        { 0, 0 },
+        { 1, 0 }
+    };
 
     public xRetryTest(IDependency dependency)
     {
@@ -19,18 +30,19 @@ public class xRetryTest
     {
         AssertDependencyUnique();
 
-        _nFact++;
-        Assert.Equal(3, _nFact);
+        _factNumCalls++;
+        Assert.Equal(3, _factNumCalls);
     }
 
     [RetryTheory]
-    [InlineData(3)]
-    public void RetryTheory(int expected)
+    [InlineData(0)]
+    [InlineData(1)]
+    public void RetryTheory(int id)
     {
         AssertDependencyUnique();
 
-        _nTheory++;
-        Assert.Equal(expected, _nTheory);
+        _theoryNumCalls[id]++;
+        Assert.Equal(3, _theoryNumCalls[id]);
     }
 
     public class NonSerializableTestData
@@ -43,21 +55,14 @@ public class xRetryTest
         }
     }
 
-    // testId => numCalls
-    private static readonly Dictionary<int, int> _defaultNumCalls = new()
-    {
-        { 0, 0 },
-        { 1, 0 }
-    };
-
     [RetryTheory]
     [MemberData(nameof(GetTestData))]
     public void RetryTheoryNonSerializableData(NonSerializableTestData nonSerializableWrapper)
     {
         AssertDependencyUnique();
 
-        _defaultNumCalls[nonSerializableWrapper.Id]++;
-        Assert.Equal(3, _defaultNumCalls[nonSerializableWrapper.Id]);
+        _nonSerializableTheoryNumCalls[nonSerializableWrapper.Id]++;
+        Assert.Equal(3, _nonSerializableTheoryNumCalls[nonSerializableWrapper.Id]);
     }
 
     public static IEnumerable<object[]> GetTestData() => new[]

--- a/Xunit.DependencyInjection.sln
+++ b/Xunit.DependencyInjection.sln
@@ -39,7 +39,9 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "XUnit.DependencyInjection.T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xunit.DependencyInjection.Template", "Xunit.DependencyInjection.Template\Xunit.DependencyInjection.Template.csproj", "{3CD9DE7F-E242-4A2A-A292-23B4E0918A41}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xunit.DependencyInjection.StaFact", "Xunit.DependencyInjection.StaFact\Xunit.DependencyInjection.StaFact.csproj", "{1AD2C55A-6F20-4B05-BCF1-FD48A3DB1D56}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xunit.DependencyInjection.StaFact", "Xunit.DependencyInjection.StaFact\Xunit.DependencyInjection.StaFact.csproj", "{1AD2C55A-6F20-4B05-BCF1-FD48A3DB1D56}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xunit.DependencyInjection.xRetry", "Xunit.DependencyInjection.xRetry\Xunit.DependencyInjection.xRetry.csproj", "{47F04277-15B1-4449-93E2-A868953126A1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -99,6 +101,10 @@ Global
 		{1AD2C55A-6F20-4B05-BCF1-FD48A3DB1D56}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1AD2C55A-6F20-4B05-BCF1-FD48A3DB1D56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1AD2C55A-6F20-4B05-BCF1-FD48A3DB1D56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47F04277-15B1-4449-93E2-A868953126A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47F04277-15B1-4449-93E2-A868953126A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47F04277-15B1-4449-93E2-A868953126A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47F04277-15B1-4449-93E2-A868953126A1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Xunit.DependencyInjection.xRetry/RetryTestCaseRunnerWrapper.cs
+++ b/Xunit.DependencyInjection.xRetry/RetryTestCaseRunnerWrapper.cs
@@ -1,0 +1,26 @@
+﻿using xRetry;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.DependencyInjection.xRetry;
+
+public class RetryTestCaseRunnerWrapper : DependencyInjectionTestCaseRunnerWrapper
+{
+    /// <inheritdoc />
+    public override Type TestCaseType => typeof(RetryTestCase);
+
+    /// <inheritdoc />
+    public override Task<RunSummary> RunAsync(IXunitTestCase testCase, IServiceProvider provider, IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus, object?[] constructorArguments, ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        if (testCase is not IRetryableTestCase retryableTestCase)
+        {
+            throw new ArgumentException("Must be a retryable test case", nameof(testCase));
+        }
+
+        return RetryTestCaseRunner.RunAsync(retryableTestCase, diagnosticMessageSink, messageBus, cancellationTokenSource,
+            blockingMessageBus => base.RunAsync(retryableTestCase, provider, diagnosticMessageSink, blockingMessageBus,
+                constructorArguments, aggregator, cancellationTokenSource));
+    }
+}

--- a/Xunit.DependencyInjection.xRetry/RetryTheoryDiscoveryAtRuntimeRunnerWrapper.cs
+++ b/Xunit.DependencyInjection.xRetry/RetryTheoryDiscoveryAtRuntimeRunnerWrapper.cs
@@ -1,0 +1,28 @@
+﻿using xRetry;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.DependencyInjection.xRetry
+{
+    public class RetryTheoryDiscoveryAtRuntimeRunnerWrapper : DependencyInjectionTheoryTestCaseRunnerWrapper
+    {
+        /// <inheritdoc />
+        public override Type TestCaseType => typeof(RetryTheoryDiscoveryAtRuntimeCase);
+
+        /// <inheritdoc />
+        public override Task<RunSummary> RunAsync(IXunitTestCase testCase, IServiceProvider provider, IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus, object?[] constructorArguments, ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+        {
+            if (testCase is not IRetryableTestCase retryableTestCase)
+            {
+                throw new ArgumentException("Must be a retryable test case", nameof(testCase));
+            }
+
+            return RetryTestCaseRunner.RunAsync(retryableTestCase, diagnosticMessageSink, messageBus,
+                cancellationTokenSource,
+                blockingMessageBus => base.RunAsync(retryableTestCase, provider, diagnosticMessageSink,
+                    blockingMessageBus, constructorArguments, aggregator, cancellationTokenSource));
+        }
+    }
+}

--- a/Xunit.DependencyInjection.xRetry/RetryTheoryDiscoveryAtRuntimeRunnerWrapper.cs
+++ b/Xunit.DependencyInjection.xRetry/RetryTheoryDiscoveryAtRuntimeRunnerWrapper.cs
@@ -2,27 +2,26 @@
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace Xunit.DependencyInjection.xRetry
+namespace Xunit.DependencyInjection.xRetry;
+
+public class RetryTheoryDiscoveryAtRuntimeRunnerWrapper : DependencyInjectionTheoryTestCaseRunnerWrapper
 {
-    public class RetryTheoryDiscoveryAtRuntimeRunnerWrapper : DependencyInjectionTheoryTestCaseRunnerWrapper
+    /// <inheritdoc />
+    public override Type TestCaseType => typeof(RetryTheoryDiscoveryAtRuntimeCase);
+
+    /// <inheritdoc />
+    public override Task<RunSummary> RunAsync(IXunitTestCase testCase, IServiceProvider provider, IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus, object?[] constructorArguments, ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
     {
-        /// <inheritdoc />
-        public override Type TestCaseType => typeof(RetryTheoryDiscoveryAtRuntimeCase);
-
-        /// <inheritdoc />
-        public override Task<RunSummary> RunAsync(IXunitTestCase testCase, IServiceProvider provider, IMessageSink diagnosticMessageSink,
-            IMessageBus messageBus, object?[] constructorArguments, ExceptionAggregator aggregator,
-            CancellationTokenSource cancellationTokenSource)
+        if (testCase is not IRetryableTestCase retryableTestCase)
         {
-            if (testCase is not IRetryableTestCase retryableTestCase)
-            {
-                throw new ArgumentException("Must be a retryable test case", nameof(testCase));
-            }
-
-            return RetryTestCaseRunner.RunAsync(retryableTestCase, diagnosticMessageSink, messageBus,
-                cancellationTokenSource,
-                blockingMessageBus => base.RunAsync(retryableTestCase, provider, diagnosticMessageSink,
-                    blockingMessageBus, constructorArguments, aggregator, cancellationTokenSource));
+            throw new ArgumentException("Must be a retryable test case", nameof(testCase));
         }
+
+        return RetryTestCaseRunner.RunAsync(retryableTestCase, diagnosticMessageSink, messageBus,
+            cancellationTokenSource,
+            blockingMessageBus => base.RunAsync(retryableTestCase, provider, diagnosticMessageSink,
+                blockingMessageBus, constructorArguments, aggregator, cancellationTokenSource));
     }
 }

--- a/Xunit.DependencyInjection.xRetry/ServiceCollectionExtensions.cs
+++ b/Xunit.DependencyInjection.xRetry/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddXRetrySupport(this IServiceCollection services)
     {
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IXunitTestCaseRunnerWrapper, RetryTestCaseRunnerWrapper>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IXunitTestCaseRunnerWrapper, RetryTheoryDiscoveryAtRuntimeRunnerWrapper>());
 
         return services;
     }

--- a/Xunit.DependencyInjection.xRetry/ServiceCollectionExtensions.cs
+++ b/Xunit.DependencyInjection.xRetry/ServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit.DependencyInjection.xRetry;
+
+// ReSharper disable once CheckNamespace
+namespace Xunit.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddXRetrySupport(this IServiceCollection services)
+    {
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IXunitTestCaseRunnerWrapper, RetryTestCaseRunnerWrapper>());
+
+        return services;
+    }
+}

--- a/Xunit.DependencyInjection.xRetry/Xunit.DependencyInjection.xRetry.csproj
+++ b/Xunit.DependencyInjection.xRetry/Xunit.DependencyInjection.xRetry.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <Description>
+      Support xRetry.
+
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddXRetrySupport();
+}
+    </Description>
+    <PackageTags>xunit ioc di DependencyInjection test skipping Retry Test-Automation</PackageTags>
+    <Version>8.0.0</Version>
+    <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
+    <UserSecretsId>78e084cc-3d7d-4b2d-ac9d-e4c148861019</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xRetry" Version="1.9.0-alpha1" />
+    <PackageReference Include="xunit.core" Version="[2.4.2, 3.0.0)" />
+
+    <ProjectReference Include="..\Xunit.DependencyInjection\Xunit.DependencyInjection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Xunit.DependencyInjection.xRetry/Xunit.DependencyInjection.xRetry.csproj
+++ b/Xunit.DependencyInjection.xRetry/Xunit.DependencyInjection.xRetry.csproj
@@ -17,7 +17,7 @@ public void ConfigureServices(IServiceCollection services)
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xRetry" Version="1.9.0-alpha1" />
+    <PackageReference Include="xRetry" Version="[1.9.0-alpha1, 2.0.0)" />
     <PackageReference Include="xunit.core" Version="[2.4.2, 3.0.0)" />
 
     <ProjectReference Include="..\Xunit.DependencyInjection\Xunit.DependencyInjection.csproj" />


### PR DESCRIPTION
Hi, I'm the author of [xRetry](https://github.com/JoshKeegan/xRetry) which retries flickering tests. Some time ago a user opened [an issue](https://github.com/JoshKeegan/xRetry/issues/131) saying that xRetry and XUnit.DependencyInjection could not be used together. This PR aims to fix that!

The new project is very similar to the ones for SkippableFact & StaFact. It's depending on a method `xRetry.RetryTestCaseRunner.RunAsync` which is currently internal to xRetry but will be made public in the next release. So for now this PR targets a pre-release version of xRetry. If you let me know whether the rest of the changes are OK, I will update the PR once it's released.