### PR TITLE
xRetry v1.9 released

### DIFF
--- a/Xunit.DependencyInjection.xRetry/Xunit.DependencyInjection.xRetry.csproj
+++ b/Xunit.DependencyInjection.xRetry/Xunit.DependencyInjection.xRetry.csproj
@@ -9,13 +9,13 @@ public void ConfigureServices(IServiceCollection services)
     services.AddXRetrySupport();
 }</Description>
     <PackageTags>xunit ioc di DependencyInjection test skipping Retry Test-Automation</PackageTags>
-    <Version>8.0.0-alpha1</Version>
+    <Version>8.0.0</Version>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xRetry" Version="[1.9.0-alpha1, 2.0.0)" />
+    <PackageReference Include="xRetry" Version="[1.9.0, 2.0.0)" />
     <PackageReference Include="xunit.core" Version="[2.4.2, 3.0.0)" />
 
     <ProjectReference Include="..\Xunit.DependencyInjection\Xunit.DependencyInjection.csproj" />


### PR DESCRIPTION
Removes pre-release tags from package & xRetry dependency.
I've tested the alpha packages together and had no issues, so if you're happy it can be released 👍 