### PR TITLE
Fixed a bug when shared host was not actually shared

### DIFF
--- a/Xunit.DependencyInjection/HostManager.cs
+++ b/Xunit.DependencyInjection/HostManager.cs
@@ -40,7 +40,7 @@ internal sealed class HostManager : IHostedService, IDisposable
 
         var host = StartupLoader.CreateHost(startupType, _assemblyName, _diagnosticMessageSink);
 
-        if (!shared) _hostMap[startupType] = host;
+        if (shared) _hostMap[startupType] = host;
 
         _hosts.Add(host);
 


### PR DESCRIPTION
I encountered a bug when host that is expected to be shared between test classes, is not in fact shared. The bug was introduced in 2a0ab0c5f13219458f6432469d3f856c595933b1; startup sharing was working correctly before.