### PR TITLE
Allow IConfiguration to be injected into ConfigureServices()

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ public class Startup
 ``` C#
 public class Startup
 {
-    public void ConfigureServices(IServiceCollection services[, HostBuilderContext context]) { }
+    public void ConfigureServices(IServiceCollection services[, HostBuilderContext context | IConfiguration configuration]) { }
 }
 ```
 
@@ -263,6 +263,18 @@ public class Startup
     public void ConfigureServices(IServiceCollection services, HostBuilderContext context)
     {
         context.XXXX;
+    }
+}
+```
+
+or
+
+``` C#
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        configuration;
     }
 }
 ```

--- a/src/Xunit.DependencyInjection/StartupLoader.cs
+++ b/src/Xunit.DependencyInjection/StartupLoader.cs
@@ -144,8 +144,16 @@ internal static class StartupLoader
                 parameters[0].ParameterType == typeof(HostBuilderContext) =>
                 (context, services) =>
                     method.Invoke(method.IsStatic ? null : startup, [context, services]),
+            2 when parameters[0].ParameterType == typeof(IServiceCollection) &&
+                parameters[1].ParameterType == typeof(IConfiguration) =>
+                (context, services) =>
+                    method.Invoke(method.IsStatic ? null : startup, [services, context.Configuration]),
+            2 when parameters[1].ParameterType == typeof(IServiceCollection) &&
+                parameters[0].ParameterType == typeof(IConfiguration) =>
+                (context, services) =>
+                    method.Invoke(method.IsStatic ? null : startup, [context.Configuration, services]),
             _ => throw new InvalidOperationException(
-                $"The '{method.Name}' method in the type '{startupType.FullName}' must have a 'IServiceCollection' parameter and optional 'HostBuilderContext' parameter.")
+                $"The '{method.Name}' method in the type '{startupType.FullName}' must have a 'IServiceCollection' parameter and optional 'HostBuilderContext' or 'IConfiguration' parameter.")
         });
     }
 

--- a/test/Xunit.DependencyInjection.Test/StartupTest.cs
+++ b/test/Xunit.DependencyInjection.Test/StartupTest.cs
@@ -158,6 +158,8 @@ public class StartupTest(IMessageSink diagnosticMessageSink)
         public void ConfigureServices(HostBuilderContext context, IServiceCollection services) { }
     }
     public class ConfigureServicesTestStartup8 { public IServiceCollection ConfigureServices(IServiceCollection services) => services.AddSingleton(this); }
+    public class ConfigureServicesTestStartup9 { public void ConfigureServices(IServiceCollection services, IConfiguration configuration) => services.AddSingleton(this); }
+    public class ConfigureServicesTestStartup10 { public void ConfigureServices(IConfiguration configuration, IServiceCollection services) => services.AddSingleton(this); }
 
     [Fact]
     public void ConfigureServicesTest()
@@ -188,10 +190,16 @@ public class StartupTest(IMessageSink diagnosticMessageSink)
 
         Assert.Throws<InvalidOperationException>(() => ConfigureServices(hostBuilder, new ConfigureServicesTestStartup8()));
 
+        ConfigureServices(hostBuilder, new ConfigureServicesTestStartup9());
+
+        ConfigureServices(hostBuilder, new ConfigureServicesTestStartup10());
+
         var services = hostBuilder.Build().Services;
         Assert.NotNull(services.GetService<ConfigureServicesTestStartup1>());
         Assert.NotNull(services.GetService<ConfigureServicesTestStartup3>());
         Assert.NotNull(services.GetService<ConfigureServicesTestStartup4>());
+        Assert.NotNull(services.GetService<ConfigureServicesTestStartup9>());
+        Assert.NotNull(services.GetService<ConfigureServicesTestStartup10>());
     }
     #endregion
 


### PR DESCRIPTION
Changes:
- Support more method sigunatures for Startup.ConfigureServices()
- Add tests for new method signatures
- Update README with syntax and examples

Reasoning:
- This change allows the (re-)use of `Startup` classes used with e.g. `WebApplicationBuilder` or `HostApplicationBuilder`, where an `IConfiguration` is readily available, but not `HostBuilderContext`:

```c#
var builder = Host.CreateApplicationBuilder(args);

var startup = new Startup();
startup.ConfigureServices(builder.Services, builder.Configuration);
```

We are commonly reusing `Startup` classes between the test projects and the services under test, and currently are forced to rebuild the configuration from services, which could be avoided with this change:

```c#
// Get rid of this
public void ConfigureServices(IServiceCollection services)
    => ConfigureServicesCore(services, services.BuildServiceProvider().GetRequiredService<IConfiguration>());
```