### PR TITLE
Add support for BuildHostApplicationBuilder

### DIFF
--- a/test/Xunit.DependencyInjection.Test/HostApplicationBuilderTest.cs
+++ b/test/Xunit.DependencyInjection.Test/HostApplicationBuilderTest.cs
@@ -19,9 +19,13 @@ public class HostApplicationBuilderTest(IConfiguration configuration, IServicePr
     [Fact]
     public void ConfigureTest() => Assert.Equal(1, Startup.Counter);
 
+    [Fact]
+    public void BuildHostApplicationBuilderTest() => Assert.True(Startup.BuildedHostApplicationBuilder);
+
     public class Startup
     {
         public static int Counter { get; private set; }
+        public static bool BuildedHostApplicationBuilder { get; private set; }
 
         public void ConfigureHostApplicationBuilder(IHostApplicationBuilder hostApplicationBuilder)
         {
@@ -30,6 +34,12 @@ public class HostApplicationBuilderTest(IConfiguration configuration, IServicePr
                 new KeyValuePair<string, string?>("Hello", "World")
             });
             hostApplicationBuilder.Services.AddSingleton<IIdGenerator, GuidIdGenerator>();
+        }
+
+        public IHost BuildHostApplicationBuilder(HostApplicationBuilder hostApplicationBuilder)
+        {
+            BuildedHostApplicationBuilder = true;
+            return hostApplicationBuilder.Build();
         }
 
         public static void Configure() => Counter++;


### PR DESCRIPTION
Support for BuildHost with the HostApplicationBuilder:

```csharp
 public class Startup
{
        // with
        public void ConfigureHostApplicationBuilder(IHostApplicationBuilder hostApplicationBuilder)
        {
            // do something here...
        }

        // will be able to
        public IHost BuildHostApplicationBuilder(HostApplicationBuilder hostApplicationBuilder)
        {
            var hostApplication = hostApplicationBuilder.Build();
            // do something here...
            return hostApplication;
        }
}
```