### PR TITLE
fix analyzer tests

### DIFF
--- a/test/Xunit.DependencyInjection.Analyzer.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/test/Xunit.DependencyInjection.Analyzer.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -1,13 +1,13 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Xunit.DependencyInjection.Analyzer.Test.Verifiers;
 
 public static partial class CSharpAnalyzerVerifier<TAnalyzer>
     where TAnalyzer : DiagnosticAnalyzer, new()
 {
-    public class Test : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>
+    public class Test : CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
     {
         public Test()
         {

--- a/test/Xunit.DependencyInjection.Analyzer.Test/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/test/Xunit.DependencyInjection.Analyzer.Test/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Xunit.DependencyInjection.Analyzer.Test.Verifiers;
 
@@ -11,15 +10,15 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
 {
     /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic()"/>
     public static DiagnosticResult Diagnostic()
-        => CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic();
+        => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic();
 
     /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(string)"/>
     public static DiagnosticResult Diagnostic(string diagnosticId)
-        => CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic(diagnosticId);
+        => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(diagnosticId);
 
     /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
     public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
-        => CSharpAnalyzerVerifier<TAnalyzer, XUnitVerifier>.Diagnostic(descriptor);
+        => CSharpAnalyzerVerifier<TAnalyzer, DefaultVerifier>.Diagnostic(descriptor);
 
     /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
     public static Task VerifyAnalyzerAsync(string source, CancellationToken cancellationToken, params DiagnosticResult[] expected)

--- a/test/Xunit.DependencyInjection.Analyzer.Test/Verifiers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/Xunit.DependencyInjection.Analyzer.Test/Verifiers/CSharpCodeFixVerifier`2+Test.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Xunit.DependencyInjection.Analyzer.Test.Verifiers;
 
@@ -9,7 +9,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     where TAnalyzer : DiagnosticAnalyzer, new()
     where TCodeFix : CodeFixProvider, new()
 {
-    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
     {
         public Test()
         {

--- a/test/Xunit.DependencyInjection.Analyzer.Test/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/test/Xunit.DependencyInjection.Analyzer.Test/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Xunit.DependencyInjection.Analyzer.Test.Verifiers;
 
@@ -13,15 +12,15 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 {
     /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic()"/>
     public static DiagnosticResult Diagnostic()
-        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic();
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic();
 
     /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(string)"/>
     public static DiagnosticResult Diagnostic(string diagnosticId)
-        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(diagnosticId);
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(diagnosticId);
 
     /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
     public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
-        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(descriptor);
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(descriptor);
 
     /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
     public static Task VerifyAnalyzerAsync(string source, CancellationToken cancellationToken, params DiagnosticResult[] expected)

--- a/test/Xunit.DependencyInjection.Analyzer.Test/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/test/Xunit.DependencyInjection.Analyzer.Test/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -1,13 +1,13 @@
 ﻿using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Xunit.DependencyInjection.Analyzer.Test.Verifiers;
 
 public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
     where TCodeRefactoring : CodeRefactoringProvider, new()
 {
-    public class Test : CSharpCodeRefactoringTest<TCodeRefactoring, XUnitVerifier>
+    public class Test : CSharpCodeRefactoringTest<TCodeRefactoring, DefaultVerifier>
     {
         public Test()
         {

--- a/test/Xunit.DependencyInjection.Analyzer.Test/Xunit.DependencyInjection.Analyzer.Test.csproj
+++ b/test/Xunit.DependencyInjection.Analyzer.Test/Xunit.DependencyInjection.Analyzer.Test.csproj
@@ -20,9 +20,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.*" />
 
     <!--https://github.com/dotnet/roslyn-sdk/blob/main/src/Microsoft.CodeAnalysis.Testing/README.md-->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.*" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.*" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
test: fix analyzer test errors

> This collection of packages previously included a number of packages for testing with specific test frameworks, such as MSTest, NUnit, and xUnit. These packages have been marked obsolete, and users are encouraged to migrate to the generic test packages.

https://github.com/dotnet/roslyn-sdk/blob/main/src/Microsoft.CodeAnalysis.Testing/README.md#obsolete-packages
failed CI: https://github.com/WeihanLi/Xunit.DependencyInjection/actions/runs/9606072333/job/26494939480

