### PR TITLE
Fixing TheoryData of T evaluation

### DIFF
--- a/src/Xunit.DependencyInjection/MethodDataAttribute.cs
+++ b/src/Xunit.DependencyInjection/MethodDataAttribute.cs
@@ -53,6 +53,8 @@ public sealed class MethodDataAttribute(string methodName, params object?[] para
         return result switch
         {
             null => null,
+            // special handling of TheoryData -- TheoryData<T> will not enumerate arrays with the below code
+            TheoryData theoryData => theoryData,
             IEnumerable<object?> dataItems => dataItems.Select(item => item switch
             {
                 null => null,
@@ -92,7 +94,7 @@ public sealed class MethodDataAttribute(string methodName, params object?[] para
     {
         var mp = method.GetParameters();
 
-        var param = Parameters == null || Parameters.Length == 0 ? new object?[mp.Length] : [..Parameters];
+        var param = Parameters == null || Parameters.Length == 0 ? new object?[mp.Length] : [.. Parameters];
 
         for (var index = 0; index < param.Length; index++)
         {

--- a/test/TestPackages.targets
+++ b/test/TestPackages.targets
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit" Version="2.9.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
   </ItemGroup>
 

--- a/test/Xunit.DependencyInjection.Test/MethodDataAttributeTest.cs
+++ b/test/Xunit.DependencyInjection.Test/MethodDataAttributeTest.cs
@@ -12,6 +12,23 @@ public class MethodDataAttributeTest
     [MethodData(nameof(TestClassA.StaticMethod), typeof(TestClassA), null, 3)]
     public void StaticMethodTest(Guid value) => Assert.Equal(RandomValue, value);
 
+    [Theory]
+    [MethodData(nameof(GetData))]
+    public void GetDataTest(ComplexType data) => Assert.Equal(RandomValue, data.Value);
+
+    private static IEnumerable<object[]> GetData(IServiceProvider services) => ActivatorUtilities.CreateInstance<MethodTheoryData>(services);
+
+    public record ComplexType(Guid Value);
+
+    private class MethodTheoryData : TheoryData<ComplexType>
+    {
+
+        public MethodTheoryData(IServiceProvider services)
+        {
+            Add(new(RandomValue));
+        }
+    }
+
     private class TestClassA
     {
         private readonly IDependency _dependency;
@@ -32,7 +49,7 @@ public class MethodDataAttributeTest
             yield return [RandomValue];
         }
 
-        public static IEnumerable<object?[]> StaticMethod([FromServices]IDependency dependency, int value)
+        public static IEnumerable<object?[]> StaticMethod([FromServices] IDependency dependency, int value)
         {
             Assert.NotNull(dependency);
 


### PR DESCRIPTION
Latest xunit 2.9.1 has an extra [IEnumerable<T>](https://github.com/xunit/xunit/blob/0f8f1563876f2cbbb9af27e0bb14b824372fd4a8/src/xunit.core/TheoryData.cs#L60) declaration that makes the code here get confused.

Handle TheoryData types more appropriately by no iterating over them.