### PR TITLE
Fix duplicate README file for Template project

### DIFF
--- a/src/Xunit.DependencyInjection.Template/Xunit.DependencyInjection.Template.csproj
+++ b/src/Xunit.DependencyInjection.Template/Xunit.DependencyInjection.Template.csproj
@@ -19,7 +19,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
     <Content Include="content/**" />
     <Compile Remove="**\*" />
   </ItemGroup>


### PR DESCRIPTION
fix build error

```
error NU5118: Warning As Error: File 'D:\a\Xunit.DependencyInjection\Xunit.DependencyInjection\src\Xunit.DependencyInjection.Template\README.md' is not added because the package already contains file '\README.md' [D:\a\Xunit.DependencyInjection\Xunit.DependencyInjection\src\Xunit.DependencyInjection.Template\Xunit.DependencyInjection.Template.csproj]
```

https://github.com/pengweiqhca/Xunit.DependencyInjection/actions/runs/12431922982/job/34710278066#annotation:4:6381
