### PR TITLE
Fix PackageProjectUrl

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,7 @@
     <AnalysisLevel>latest-Recommended</AnalysisLevel>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
 
-    <PackageProjectUrl>$(RepositoryUrl)/src/$(MSBuildProjectName)</PackageProjectUrl>
+    <PackageProjectUrl>$(RepositoryUrl)/tree/main/src/$(MSBuildProjectName)</PackageProjectUrl>
 
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Fix "Project website" links in NuGet.org 404ing.

For example, [Xunit.DependencyInjection.Logging@10.0.0](https://www.nuget.org/packages/Xunit.DependencyInjection.Logging/10.0.0) points to `https://github.com/pengweiqhca/Xunit.DependencyInjection/src/Xunit.DependencyInjection.Logging`, which just shows "Not Found".

To see the content, `/tree/{branch}` is needed before the repository content path.
